### PR TITLE
Updated validateSettings and redcap_module_configure_button_display functions for PHP 8.x

### DIFF
--- a/REDCapPRO.php
+++ b/REDCapPRO.php
@@ -326,9 +326,9 @@ class REDCapPRO extends AbstractExternalModule
      * 
      * @return bool
      */
-    function redcap_module_configure_button_display($project_id)
+    function redcap_module_configure_button_display()
     {
-        return empty($project_id);
+        return true;
     }
 
 
@@ -871,7 +871,7 @@ class REDCapPRO extends AbstractExternalModule
      * 
      * @return string|null if not null, the error message to show to user
      */
-    function validateSettings(array $settings)
+    function validateSettings($settings)
     {
 
         $message = NULL;


### PR DESCRIPTION
For PHP 8.1 compatibility AND REDCap EM Framework, I updated the function declarations for:
validateSettings
and
redcap_module_configure_button_display
to match the declarations in AbstractExternalModule.php

Removed the "array" declaration from the $settings parameter in validateSettings in order to make it match to the function definition in the AbstractExternalModule method

Updated redcap_module_configure_button_display and removed the $project_id parameter in order to match with the method declaration in the AbstractExternalModule. This only returns true now.